### PR TITLE
internal/gemini, internal/ollama: add model name to constructor

### DIFF
--- a/internal/gaby/main.go
+++ b/internal/gaby/main.go
@@ -413,7 +413,7 @@ func main() {
 	// Ran during setup: gh.Add("golang/go")
 
 	dc := docs.New(db)
-	ai, err := gemini.NewClient(ctx, lg, sdb, http.DefaultClient)
+	ai, err := gemini.NewClient(ctx, lg, sdb, http.DefaultClient, "text-embedding-004")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/gemini/gemini.go
+++ b/internal/gemini/gemini.go
@@ -49,15 +49,17 @@ func Scrub(req *http.Request) error {
 
 // A Client represents a connection to Gemini.
 type Client struct {
-	slog      *slog.Logger
-	genai     *genai.Client
-	modelName string
+	slog  *slog.Logger
+	genai *genai.Client
+	model string
 }
 
 // NewClient returns a connection to Gemini, using the given logger and HTTP client.
 // It expects to find a secret of the form "AIza..." or "user:AIza..." in sdb
 // under the name "ai.google.dev".
-func NewClient(ctx context.Context, lg *slog.Logger, sdb secret.DB, hc *http.Client, mn string) (*Client, error) {
+// The model is the model name to use for embedding,
+// such as text-embedding-004.
+func NewClient(ctx context.Context, lg *slog.Logger, sdb secret.DB, hc *http.Client, model string) (*Client, error) {
 	key, ok := sdb.Get("ai.google.dev")
 	if !ok {
 		return nil, fmt.Errorf("missing api key for ai.google.dev")
@@ -81,7 +83,7 @@ func NewClient(ctx context.Context, lg *slog.Logger, sdb secret.DB, hc *http.Cli
 		return nil, err
 	}
 
-	return &Client{slog: lg, genai: ai, modelName: mn}, nil
+	return &Client{slog: lg, genai: ai, model: model}, nil
 }
 
 // withKey returns a new http.Client that is the same as hc
@@ -115,7 +117,7 @@ const maxBatch = 100 // empirical limit
 // EmbedDocs returns the vector embeddings for the docs,
 // implementing [llm.Embedder].
 func (c *Client) EmbedDocs(ctx context.Context, docs []llm.EmbedDoc) ([]llm.Vector, error) {
-	model := c.genai.EmbeddingModel(c.modelName)
+	model := c.genai.EmbeddingModel(c.model)
 	var vecs []llm.Vector
 	for docs := range slices.Chunk(docs, maxBatch) {
 		b := model.NewBatch()

--- a/internal/gemini/gemini.go
+++ b/internal/gemini/gemini.go
@@ -49,14 +49,15 @@ func Scrub(req *http.Request) error {
 
 // A Client represents a connection to Gemini.
 type Client struct {
-	slog  *slog.Logger
-	genai *genai.Client
+	slog      *slog.Logger
+	genai     *genai.Client
+	modelName string
 }
 
 // NewClient returns a connection to Gemini, using the given logger and HTTP client.
 // It expects to find a secret of the form "AIza..." or "user:AIza..." in sdb
 // under the name "ai.google.dev".
-func NewClient(ctx context.Context, lg *slog.Logger, sdb secret.DB, hc *http.Client) (*Client, error) {
+func NewClient(ctx context.Context, lg *slog.Logger, sdb secret.DB, hc *http.Client, mn string) (*Client, error) {
 	key, ok := sdb.Get("ai.google.dev")
 	if !ok {
 		return nil, fmt.Errorf("missing api key for ai.google.dev")
@@ -80,7 +81,7 @@ func NewClient(ctx context.Context, lg *slog.Logger, sdb secret.DB, hc *http.Cli
 		return nil, err
 	}
 
-	return &Client{slog: lg, genai: ai}, nil
+	return &Client{slog: lg, genai: ai, modelName: mn}, nil
 }
 
 // withKey returns a new http.Client that is the same as hc
@@ -114,7 +115,7 @@ const maxBatch = 100 // empirical limit
 // EmbedDocs returns the vector embeddings for the docs,
 // implementing [llm.Embedder].
 func (c *Client) EmbedDocs(ctx context.Context, docs []llm.EmbedDoc) ([]llm.Vector, error) {
-	model := c.genai.EmbeddingModel("text-embedding-004")
+	model := c.genai.EmbeddingModel(c.modelName)
 	var vecs []llm.Vector
 	for docs := range slices.Chunk(docs, maxBatch) {
 		b := model.NewBatch()

--- a/internal/gemini/gemini.go
+++ b/internal/gemini/gemini.go
@@ -57,8 +57,7 @@ type Client struct {
 // NewClient returns a connection to Gemini, using the given logger and HTTP client.
 // It expects to find a secret of the form "AIza..." or "user:AIza..." in sdb
 // under the name "ai.google.dev".
-// The model is the model name to use for embedding,
-// such as text-embedding-004.
+// The model is the model name to use for embedding, such as text-embedding-004.
 func NewClient(ctx context.Context, lg *slog.Logger, sdb secret.DB, hc *http.Client, model string) (*Client, error) {
 	key, ok := sdb.Get("ai.google.dev")
 	if !ok {

--- a/internal/gemini/gemini_test.go
+++ b/internal/gemini/gemini_test.go
@@ -49,7 +49,7 @@ func newTestClient(t *testing.T, rrfile string) *Client {
 	rr.Scrub(Scrub)
 	sdb := secret.ReadOnlyMap{"ai.google.dev": "nokey"}
 
-	c, err := NewClient(ctx, lg, sdb, rr.Client())
+	c, err := NewClient(ctx, lg, sdb, rr.Client(), "text-embedding-004")
 	check(err)
 
 	return c

--- a/internal/ollama/ollama.go
+++ b/internal/ollama/ollama.go
@@ -75,12 +75,12 @@ func (c *Client) EmbedDocs(ctx context.Context, docs []llm.EmbedDoc) ([]llm.Vect
 	return vecs, nil
 }
 
-func embed(ctx context.Context, hc *http.Client, embedURL *url.URL, inputs []string, mn string) ([]llm.Vector, error) {
+func embed(ctx context.Context, hc *http.Client, embedURL *url.URL, inputs []string, model string) ([]llm.Vector, error) {
 	embReq := struct {
 		Model string   `json:"model"`
 		Input []string `json:"input"`
 	}{
-		Model: mn,
+		Model: model,
 		Input: inputs,
 	}
 	erj, err := json.Marshal(embReq)

--- a/internal/ollama/ollama.go
+++ b/internal/ollama/ollama.go
@@ -27,16 +27,17 @@ import (
 
 // A Client represents a connection to Ollama.
 type Client struct {
-	slog      *slog.Logger
-	hc        *http.Client
-	url       *url.URL // url of the ollama server
-	modelName string
+	slog  *slog.Logger
+	hc    *http.Client
+	url   *url.URL // url of the ollama server
+	model string
 }
 
 // NewClient returns a connection to Ollama server. If empty, the
 // server is assumed to be hosted at http://127.0.0.1:11434.
-// ideally, use the largest ollama embedding model, ie: "mxbai-embed-large"
-func NewClient(lg *slog.Logger, hc *http.Client, server string, mn string) (*Client, error) {
+// The model is the model name to use for embedding,
+// A typical model for embedding is "mxbai-embed-large".
+func NewClient(lg *slog.Logger, hc *http.Client, server string, model string) (*Client, error) {
 	if server == "" {
 		host := os.Getenv("OLLAMA_HOST")
 		if host == "" {
@@ -48,7 +49,7 @@ func NewClient(lg *slog.Logger, hc *http.Client, server string, mn string) (*Cli
 	if err != nil {
 		return nil, err
 	}
-	return &Client{slog: lg, hc: hc, url: u, modelName: mn}, nil
+	return &Client{slog: lg, hc: hc, url: u, model: model}, nil
 }
 
 const maxBatch = 512 // default physical batch size in ollama
@@ -65,7 +66,7 @@ func (c *Client) EmbedDocs(ctx context.Context, docs []llm.EmbedDoc) ([]llm.Vect
 			input := doc.Title + "\n\n" + doc.Text
 			inputs = append(inputs, input)
 		}
-		vs, err := embed(ctx, c.hc, embedURL, inputs, c.modelName)
+		vs, err := embed(ctx, c.hc, embedURL, inputs, c.model)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/ollama/ollama.go
+++ b/internal/ollama/ollama.go
@@ -35,7 +35,7 @@ type Client struct {
 
 // NewClient returns a connection to Ollama server. If empty, the
 // server is assumed to be hosted at http://127.0.0.1:11434.
-// The model is the model name to use for embedding,
+// The model is the model name to use for embedding.
 // A typical model for embedding is "mxbai-embed-large".
 func NewClient(lg *slog.Logger, hc *http.Client, server string, model string) (*Client, error) {
 	if server == "" {

--- a/internal/ollama/ollama_test.go
+++ b/internal/ollama/ollama_test.go
@@ -44,7 +44,7 @@ func newTestClient(t *testing.T, rrfile string) *Client {
 	rr, err := httprr.Open(rrfile, http.DefaultTransport)
 	check(err)
 
-	c, err := NewClient(lg, rr.Client(), "")
+	c, err := NewClient(lg, rr.Client(), "", "mxbai-embed-large")
 	check(err)
 
 	return c


### PR DESCRIPTION
Adding the model name allows using different models as needed
and also avoids hard-coding what will eventually become an old model.